### PR TITLE
Fix Cleave never casting in /icleave rotation

### DIFF
--- a/warrior/action.lua
+++ b/warrior/action.lua
@@ -185,10 +185,20 @@ end
 function IWin:Cleave()
 	if IWin:IsSpellLearnt("Cleave") then
 		if IWin:IsRageAvailable("Cleave")
-			or UnitMana("player") > 80 then
-				IWin_CombatVar["swingAttackQueued"] = true
-				IWin_CombatVar["startAttackThrottle"] = GetTime() + 0.2
-				CastSpellByName("Cleave")
+			or (
+					UnitMana("player") > 60
+					and (
+							not IWin:IsSpellLearnt("Whirlwind")
+							or IWin:GetCooldownRemaining("Whirlwind") > 0
+						)
+					and (
+							not IWin:IsSpellLearnt("Sweeping Strikes")
+							or IWin:GetCooldownRemaining("Sweeping Strikes") > 0
+						)
+				) then
+					IWin_CombatVar["swingAttackQueued"] = true
+					IWin_CombatVar["startAttackThrottle"] = GetTime() + 0.2
+					CastSpellByName("Cleave")
 		else
 			--SpellStopCasting()
 		end


### PR DESCRIPTION
## Summary

- Fixes Cleave never firing in `/icleave` and `/ihodor` rotations by replacing the weak rage fallback with a smart conditional mirroring the proven `HeroicStrike()` pattern
- Single function change in `warrior/action.lua`, no rotation reordering or reservation system modifications
- This change results in Slam never being used for /icleave
## Change

**`warrior/action.lua`** — `Cleave()` function: replaced `or UnitMana("player") > 80` with a conditional fallback that casts Cleave when:
1. Player has **> 60 rage** (leaves 40+ after Cleave's 20 cost — covers Whirlwind at 25 with buffer)
2. **Whirlwind** is not learned or is on cooldown
3. **Sweeping Strikes** is not learned or is on cooldown

This prevents Cleave from consuming rage needed for key AOE abilities while still allowing it to fire as a rage dump when safe.

## Test plan

- [x] Verified in-game that Cleave now casts during `/icleave` rotation
- [x] `/ihodor` — verify Cleave also works in tank rotation
- [x] `/idps` — verify no regression (does not call Cleave)

Closes shahern004/IWinEnhanced#1